### PR TITLE
Switch runtime and SDK to freedesktop.org

### DIFF
--- a/me.kozec.syncthingtk.yaml
+++ b/me.kozec.syncthingtk.yaml
@@ -1,8 +1,8 @@
 app-id: me.kozec.syncthingtk
 
-runtime: org.gnome.Platform
-runtime-version: '41'
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang
 
@@ -52,6 +52,21 @@ modules:
   - python2-bcrypt.json
   - python2-pycairo.json
   - python2-pygobject.json
+  
+  # Pulling in libnotify again pretty much just for the GIR bindings.
+  - name: libnotify
+    buildsystem: meson
+    config-opts:
+      - -Dintrospection=enabled
+      - -Dtests=false
+      - -Dman=false
+      - -Dgtk_doc=false
+      - -Ddocbook_docs=disabled
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/GNOME/libnotify.git
+        tag: 0.7.9
+        commit: 98a4bf483a69c6436311bcb9834d9d93235c96b7
 
   - syncthing.yaml
 


### PR DESCRIPTION
Hi there. Syncthing GTK isn't really a GNOME app, as it does not use any libraries or conventions that are specific to GNOME, and it uses paradigms that are unsupported by GNOME, namely the status indicator via KDE's protocol and AppIndicator. As such, I think it is appropriate for it to target the freedesktop.org runtime instead of the GNOME one. An extra pro of this is that you also get twice as long to catch up with new runtime versions.

The main hitch is that FD.O does not include GIR bindings for libnotify, so this does rebuild libnotify just to get the GIR bindings.