### PR TITLE
Bump org.freedesktop.Platform to 23.08

### DIFF
--- a/net.syncthing.syncthing.yaml
+++ b/net.syncthing.syncthing.yaml
@@ -1,7 +1,7 @@
 app-id: net.syncthing.syncthing
 
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang


### PR DESCRIPTION
I believe this should "just work" and resolve the obsolete dependency on `org.gnome.Platform` version 43.