### PR TITLE
syncthing: restrict x-checker-data to version 1

### DIFF
--- a/syncthing.yaml
+++ b/syncthing.yaml
@@ -29,4 +29,6 @@ sources:
       type: anitya
       project-id: 11814
       url-template: https://github.com/syncthing/syncthing/releases/download/v$version/syncthing-source-v$version.tar.gz
+      versions:
+        <: 2
 


### PR DESCRIPTION
The desktop app is not yet fully compatible with version 2: https://github.com/syncthing-gtk/syncthing-gtk/issues/102#issuecomment-3540260609